### PR TITLE
Fix react-hot-loader webpack config override

### DIFF
--- a/config/webpack/demo/webpack.config.hot.js
+++ b/config/webpack/demo/webpack.config.hot.js
@@ -3,12 +3,16 @@
 var _ = require("lodash"); // devDependency
 var base = require("./webpack.config.dev");
 
-// Update our own module version.
+// Clone our own module object.
 var mod = _.cloneDeep(base.module);
-// First loader needs react hot.
-mod.loaders[0].loaders = [
-  require.resolve("react-hot-loader")
-].concat(mod.loaders[0].loaders);
+
+// Update loaders array. First loader needs react hot.
+mod.loaders[0].loaders = [require.resolve("react-hot-loader")]
+  .concat(mod.loaders[0].loader ? [mod.loaders[0].loader] : [])
+  .concat(mod.loaders[0].loaders || []);
+
+// Remove single loader if any.
+mod.loaders[0].loader = null;
 
 module.exports = _.merge({}, _.omit(base, "entry", "module"), {
   entry: {

--- a/config/webpack/demo/webpack.config.hot.js
+++ b/config/webpack/demo/webpack.config.hot.js
@@ -5,14 +5,15 @@ var base = require("./webpack.config.dev");
 
 // Clone our own module object.
 var mod = _.cloneDeep(base.module);
+var firstLoader = mod.loaders[0];
 
-// Update loaders array. First loader needs react hot.
-mod.loaders[0].loaders = [require.resolve("react-hot-loader")]
-  .concat(mod.loaders[0].loader ? [mod.loaders[0].loader] : [])
-  .concat(mod.loaders[0].loaders || []);
+// Update loaders array. First loader needs react-hot-loader.
+firstLoader.loaders = [require.resolve("react-hot-loader")]
+  .concat(firstLoader.loader ? [firstLoader.loader] : [])
+  .concat(firstLoader.loaders || []);
 
 // Remove single loader if any.
-mod.loaders[0].loader = null;
+firstLoader.loader = null;
 
 module.exports = _.merge({}, _.omit(base, "entry", "module"), {
   entry: {


### PR DESCRIPTION
This fixes the issue we inherited from `builder-react-component`: https://github.com/FormidableLabs/builder-react-component/issues/16

Still TODO is to update the boilerplate README with `builder run hot` instructions.
