### PR TITLE
Bug docs build destination

### DIFF
--- a/config/webpack/docs/webpack.config.dev.js
+++ b/config/webpack/docs/webpack.config.dev.js
@@ -1,17 +1,22 @@
 /*globals __dirname:false */
 "use strict";
 
+var path = require("path");
 var webpack = require("webpack");
+
+// Replace with `__dirname` if using in project root.
+var ROOT = process.cwd();
+var OUTPUT_DIR = path.join(ROOT, "docs", "build");
 
 module.exports = {
 
   devServer: {
-    contentBase: __dirname,
+    contentBase: ROOT,
     noInfo: false
   },
 
   output: {
-    path: __dirname,
+    path: OUTPUT_DIR,
     filename: "main.js"
   },
 

--- a/config/webpack/docs/webpack.config.static.js
+++ b/config/webpack/docs/webpack.config.static.js
@@ -1,11 +1,9 @@
 "use strict";
 
 var CleanPlugin = require("clean-webpack-plugin");
-var path = require("path");
 var StaticSiteGeneratorPlugin = require("static-site-generator-webpack-plugin");
 var StatsWriterPlugin = require("webpack-stats-plugin").StatsWriterPlugin;
 var DefinePlugin = require("webpack").DefinePlugin;
-
 
 var base = require("./webpack.config.dev.js");
 
@@ -21,14 +19,14 @@ module.exports = {
     main: "./docs/static-render-entry.jsx"
   },
   output: {
-    path: path.join(__dirname, "..", OUTPUT_DIR),
+    path: base.output.path,
     filename: "main.[hash].js",
     libraryTarget: "umd" // Needs to be universal for `static-site-generator-webpack-plugin` to work
   },
   resolve: base.resolve,
   module: base.module,
   plugins: [
-    new CleanPlugin([ "../" + OUTPUT_DIR ]),
+    new CleanPlugin(OUTPUT_DIR),
     new StatsWriterPlugin({
       filename: "stats.json"
     }),

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "open-dev": "builder concurrent dev open-demo",
     "open-hot": "builder concurrent hot open-demo",
     "docs-dev": "webpack-dev-server --port 3000 --config node_modules/builder-victory-component/config/webpack/docs/webpack.config.dev.js --content-base docs",
-    "docs-hot": "webpack-dev-server --port 3000 --config dnode_modules/builder-victory-component/config/webpack/ocs/webpack.config.hot.js --hot --content-base docs",
+    "docs-hot": "webpack-dev-server --port 3000 --config node_modules/builder-victory-component/config/webpack/docs/webpack.config.hot.js --hot --content-base docs",
     "docs-build-static": "webpack --config node_modules/builder-victory-component/config/webpack/docs/webpack.config.static.js --progress",
     "push-gh-pages": "git subtree push --prefix docs/build origin gh-pages",
     "lint-server": "eslint --color -c node_modules/builder-victory-component/config/eslint/.eslintrc-server *.js",


### PR DESCRIPTION
Fixes an issue with doc generation paths: Docs were being built inside the archetype `node_modules/` tree. Not what we intended.

Also fixes an issue with `builder run docs-hot`.
