### PR TITLE
Fix issue with global React in dist

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -28,7 +28,7 @@ module.exports = {
   externals: [
     {
       "react": {
-        root: "Victory",
+        root: "React",
         commonjs2: "react",
         commonjs: "react",
         amd: "react"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "lodash": "^3.10.1",
     "radium": "^0.15.3",
     "rimraf": "^2.4.0",
-    "webpack": "^1.11.0"
+    "webpack": "^1.12.9"
   },
   "devDependencies": {
     "eslint": "^1.10.1",


### PR DESCRIPTION
Including Victory via `npm CDN` currently does not work:

```
Uncaught TypeError: Cannot read property 'Component' of undefined <-- trying to access React.Component
Uncaught ReferenceError: Victory is not defined
```

This fixes that issue.
- Webpack: Export React as external, not Victory
- Upgrade Webpack to 1.12.9 for a fix to https://github.com/webpack/webpack/issues/1082
