### PR TITLE
Upgrade radium to 0.16.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "babel-core": "^5.8.22",
     "babel-loader": "^5.3.2",
     "lodash": "^3.10.1",
-    "radium": "^0.15.3",
+    "radium": "^0.16.2",
     "rimraf": "^2.4.0",
     "webpack": "^1.12.9"
   },


### PR DESCRIPTION
Before we release a new version of the archetype, we need to finish https://github.com/FormidableLabs/victory/issues/167. However, I'm going to merge this and point to the github sha in `victory` in order to publish a new version of the docs site.
