### PR TITLE
fix enzyme + sinon + webpack issue

### DIFF
--- a/config/webpack/webpack.config.test.js
+++ b/config/webpack/webpack.config.test.js
@@ -8,6 +8,7 @@ var prodCfg = require("./webpack.config");
 
 // Replace with `__dirname` if using in project root.
 var ROOT = process.cwd();
+var _ = require("lodash"); // devDependency
 
 module.exports = {
   cache: true,
@@ -19,10 +20,23 @@ module.exports = {
   },
   resolve: _.merge({}, prodCfg.resolve, {
     alias: {
+      // enzyme webpack issue https://github.com/airbnb/enzyme/issues/47
+       sinon: "node_modules/sinon/pkg/sinon.js",
       // Allow root import of `src/FOO` from ROOT/src.
       src: path.join(ROOT, "src")
     }
   }),
-  module: prodCfg.module,
+  // enzyme webpack issue https://github.com/airbnb/enzyme/issues/47
+  externals: {
+    'cheerio': 'window',
+    'react/lib/ExecutionEnvironment': true,
+    'react/lib/ReactContext': true
+  },
+  module: _.assign({}, prodCfg.module, {
+    // enzyme webpack issue https://github.com/airbnb/enzyme/issues/47
+    noParse: [
+      /\/sinon\.js/
+    ]
+  }),
   devtool: "source-map"
 };

--- a/config/webpack/webpack.config.test.js
+++ b/config/webpack/webpack.config.test.js
@@ -3,7 +3,6 @@
  * Webpack frontend test configuration.
  */
 var path = require("path");
-var _ = require("lodash"); // devDependency
 var prodCfg = require("./webpack.config");
 
 // Replace with `__dirname` if using in project root.
@@ -21,16 +20,16 @@ module.exports = {
   resolve: _.merge({}, prodCfg.resolve, {
     alias: {
       // enzyme webpack issue https://github.com/airbnb/enzyme/issues/47
-       sinon: "node_modules/sinon/pkg/sinon.js",
+      sinon: "node_modules/sinon/pkg/sinon.js",
       // Allow root import of `src/FOO` from ROOT/src.
       src: path.join(ROOT, "src")
     }
   }),
   // enzyme webpack issue https://github.com/airbnb/enzyme/issues/47
   externals: {
-    'cheerio': 'window',
-    'react/lib/ExecutionEnvironment': true,
-    'react/lib/ReactContext': true
+    "cheerio": "window",
+    "react/lib/ExecutionEnvironment": true,
+    "react/lib/ReactContext": true
   },
   module: _.assign({}, prodCfg.module, {
     // enzyme webpack issue https://github.com/airbnb/enzyme/issues/47


### PR DESCRIPTION
cc/ @coopy 

This change to the test webpack config allows us to start using Enzyme for testing. See this enzyme issue https://github.com/airbnb/enzyme/issues/47

I tested this change via `node_modules` in VictoryChart
