### PR TITLE
fix babel loader syntax

### DIFF
--- a/config/webpack/docs/webpack.config.dev.js
+++ b/config/webpack/docs/webpack.config.dev.js
@@ -37,7 +37,7 @@ module.exports = {
       {
         test: /\.jsx?$/,
         exclude: [/node_modules/],
-        loaders: ["babel-loader?stage=0"]
+        loader: require.resolve("babel-loader")
       }
     ]
   },


### PR DESCRIPTION
cc/ @tptee 

This was breaking docs in consuming repos. This change should be repeated in `builder-radium-component`
