### PR TITLE
remove formidable-landers dep

### DIFF
--- a/dev/package.json
+++ b/dev/package.json
@@ -28,7 +28,6 @@
     "eslint-config-defaults": "^7.0.1",
     "eslint-plugin-filenames": "^0.1.2",
     "eslint-plugin-react": "^3.6.2",
-    "formidable-landers": "0.0.2",
     "http-server": "^0.8.5",
     "isparta-loader": "^2.0.0",
     "karma": "^0.13.9",


### PR DESCRIPTION
I think I finally found the trouble maker! This dep isn't used in most victory components anyway, and those that do use it include their own version. 
