### PR TITLE
Fix docs-hot configuration

### DIFF
--- a/config/webpack/docs/webpack.config.dev.js
+++ b/config/webpack/docs/webpack.config.dev.js
@@ -2,7 +2,6 @@
 "use strict";
 
 var path = require("path");
-var webpack = require("webpack");
 
 // Replace with `__dirname` if using in project root.
 var ROOT = process.cwd();
@@ -10,9 +9,8 @@ var OUTPUT_DIR = path.join(ROOT, "docs", "build");
 
 module.exports = {
 
-  devServer: {
-    contentBase: ROOT,
-    noInfo: false
+  entry: {
+    app: ["./docs/entry.jsx"]
   },
 
   output: {
@@ -20,28 +18,31 @@ module.exports = {
     filename: "main.js"
   },
 
-  cache: true,
-  devtool: "source-map",
-  entry: {
-    app: ["./docs/app.jsx"]
+  devServer: {
+    contentBase: ROOT,
+    noInfo: false
   },
+
+  cache: true,
+
+  devtool: "source-map",
+
   stats: {
     colors: true,
     reasons: true
   },
+
   resolve: {
     extensions: ["", ".js", ".jsx"]
   },
+
   module: {
     loaders: [
       {
         test: /\.jsx?$/,
         exclude: [/node_modules/],
-        loader: require.resolve("babel-loader")
+        loaders: [require.resolve("babel-loader")]
       }
     ]
-  },
-  plugins: [
-    new webpack.NoErrorsPlugin()
-  ]
+  }
 };

--- a/config/webpack/docs/webpack.config.hot.js
+++ b/config/webpack/docs/webpack.config.hot.js
@@ -4,14 +4,14 @@ var _ = require("lodash");
 var base = require("./webpack.config.dev");
 
 // Update our own module version.
-var mod = _.cloneDeep(base.module);
+var baseModule = _.cloneDeep(base.module);
 // First loader needs react hot.
-mod.loaders[0].loaders = ["react-hot"].concat(mod.loaders[0].loaders);
+baseModule.loaders[0].loaders = ["react-hot"].concat(baseModule.loaders[0].loaders);
 
 module.exports = _.merge({}, _.omit(base, "entry", "module"), {
   entry: {
-    app: ["webpack/hot/dev-server", "./docs/app.jsx"]
+    app: ["webpack/hot/only-dev-server", "./docs/entry.jsx"]
   },
 
-  module: mod
+  module: baseModule
 });

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "open-dev": "builder concurrent dev open-demo",
     "open-hot": "builder concurrent hot open-demo",
     "docs-dev": "webpack-dev-server --port 3000 --config node_modules/builder-victory-component/config/webpack/docs/webpack.config.dev.js --content-base docs",
-    "docs-hot": "webpack-dev-server --port 3000 --config node_modules/builder-victory-component/config/webpack/docs/webpack.config.hot.js --hot --content-base docs",
+    "docs-hot": "webpack-dev-server --port 3000 --config node_modules/builder-victory-component/config/webpack/docs/webpack.config.hot.js --inline --hot --content-base docs",
     "lint-source": "eslint --color --ext .js,.jsx src",
     "lint-demo": "eslint --color --ext .js,.jsx demo",
     "lint-test": "eslint --color --ext .js,.jsx test",


### PR DESCRIPTION
The webpack hot config baseModule mutation was using plural "loaders", but the webpack dev configuration was using singular "loader". Fixed that.

Now using `--inline` webpack-dev-server option.

Also change docs entry point to `entry.jsx` for consistency.
