### PR TITLE
Update webpack config so that cheerio behaves properly w. enzyme

### DIFF
--- a/config/webpack/webpack.config.test.js
+++ b/config/webpack/webpack.config.test.js
@@ -20,6 +20,9 @@ module.exports = {
     publicPath: "/assets/"
   },
   resolve: _.merge({}, prodCfg.resolve, {
+    // enzyme webpack issue https://github.com/airbnb/enzyme/issues/47
+    // Necessary for `cheerio` to load
+    extensions: prodCfg.resolve.extensions.concat([".json"]),
     alias: {
       // enzyme webpack issue https://github.com/airbnb/enzyme/issues/47
       sinon: "node_modules/sinon/pkg/sinon.js",
@@ -28,16 +31,25 @@ module.exports = {
     }
   }),
   // enzyme webpack issue https://github.com/airbnb/enzyme/issues/47
+  // Please note that externals may have to change for versions of React
+  // other than 0.14.x
   externals: {
-    "cheerio": "window",
     "react/lib/ExecutionEnvironment": true,
-    "react/lib/ReactContext": true
+    "react/lib/ReactContext": true,
+    "text-encoding": "window"
   },
   module: _.assign({}, prodCfg.module, {
     // enzyme webpack issue https://github.com/airbnb/enzyme/issues/47
     noParse: [
       /\/sinon\.js/
-    ]
+    ],
+    // enzyme webpack issue https://github.com/airbnb/enzyme/issues/47
+    loaders: (prodCfg.module.loaders || []).concat([
+      {
+        test: /\.json$/,
+        loader: "json"
+      }
+    ])
   }),
   devtool: "source-map"
 };

--- a/config/webpack/webpack.config.test.js
+++ b/config/webpack/webpack.config.test.js
@@ -47,7 +47,7 @@ module.exports = {
     loaders: (prodCfg.module.loaders || []).concat([
       {
         test: /\.json$/,
-        loader: "json"
+        loader: archDevRequire.resolve("json-loader")
       }
     ])
   }),

--- a/dev/package.json
+++ b/dev/package.json
@@ -24,6 +24,7 @@
     "formidable-landers": "^0.1.1",
     "http-server": "^0.8.5",
     "isparta-loader": "^2.0.0",
+    "json-loader": "^0.5.4",
     "karma": "^0.13.9",
     "karma-chrome-launcher": "^0.2.0",
     "karma-coverage": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "builder-support": "^0.3.0",
     "eslint": "^1.10.1",
     "eslint-config-defaults": "^7.0.1",
-    "eslint-plugin-filenames": "^0.1.2"
+    "eslint-plugin-filenames": "^0.1.2",
+    "json-loader": "^0.5.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "builder-support": "^0.3.0",
     "eslint": "^1.10.1",
     "eslint-config-defaults": "^7.0.1",
-    "eslint-plugin-filenames": "^0.1.2",
-    "json-loader": "^0.5.4"
+    "eslint-plugin-filenames": "^0.1.2"
   }
 }


### PR DESCRIPTION
This PR allows devs to use cheerio and chai-enzyme in tests, where previously tests would error out.

Before making these changes calls to chai-enzyme assertions that depend on cheerio would result in an error message akin to `"TypeError: '[object DOMWindow]' is not a function (evaluating '(0, _cheerio2.default)(html)’)"`. A similar error occurs when using cheerio directly.

It is unclear to me why we needed to add "text-encoding" to the externals. Changes were made following advice @ https://github.com/airbnb/enzyme/issues/47

Tested config locally w. npm link against Victory Core & Victory Pie, but had to do some finagling to get it to work thanks to `json-loader` dep & @ryan-roemer's module pattern changes - would appreciate if someone more familiar w. builder tested locally prior to merging :)
