### PR TITLE
remove extension from entry path

### DIFF
--- a/config/webpack/demo/webpack.config.dev.js
+++ b/config/webpack/demo/webpack.config.dev.js
@@ -16,7 +16,7 @@ module.exports = {
   cache: true,
   devtool: "source-map",
   entry: {
-    app: ["./demo/app.jsx"]
+    app: ["./demo/app"]
   },
   stats: {
     colors: true,

--- a/config/webpack/demo/webpack.config.hot.js
+++ b/config/webpack/demo/webpack.config.hot.js
@@ -20,7 +20,7 @@ module.exports = _.merge({}, _.omit(base, "entry", "module"), {
   entry: {
     app: [
       archDevRequire.resolve("webpack/hot/only-dev-server"),
-      "./demo/app.jsx"
+      "./demo/app"
     ]
   },
 

--- a/config/webpack/docs/webpack.config.dev.js
+++ b/config/webpack/docs/webpack.config.dev.js
@@ -10,7 +10,7 @@ var OUTPUT_DIR = path.join(ROOT, "docs", "build");
 module.exports = {
 
   entry: {
-    app: ["./docs/entry.jsx"]
+    app: ["./docs/entry"]
   },
 
   output: {

--- a/config/webpack/docs/webpack.config.hot.js
+++ b/config/webpack/docs/webpack.config.hot.js
@@ -20,7 +20,7 @@ module.exports = _.merge({}, _.omit(base, "entry", "module"), {
   entry: {
     app: [
       archDevRequire.resolve("webpack/hot/only-dev-server"),
-      "./docs/entry.jsx"
+      "./docs/entry"
     ]
   },
 


### PR DESCRIPTION
This works without the a path extension. @ryan-roemer is it okay to leave it off or should I change it to `.js`? If it's all the same to you I'd prefer to leave it off so that this isn't a breaking change.
