### PR TITLE
update to newest version of babel-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "babel-cli": "^6.6.5",
-    "babel-core": "^6.6.4",
+    "babel-core": "^6.10.4",
     "babel-loader": "^6.2.4",
     "babel-plugin-lodash": "^3.1.2",
     "babel-preset-es2015": "^6.6.0",


### PR DESCRIPTION
This updates the version of babel-core being used in order to stop running a deprecated version of minimatch, which was causing WARN messages for users of Victory. https://github.com/FormidableLabs/victory/issues/286

@boygirl 
