### PR TITLE
Update .eslintrc-source

### DIFF
--- a/config/eslint/.eslintrc-source
+++ b/config/eslint/.eslintrc-source
@@ -7,3 +7,4 @@ rules:
   # Don't check victory deps until bugfix for NODE_PATH uptream.
   # https://github.com/benmosher/eslint-plugin-import/issues/142
   import/no-unresolved: [2, { ignore: ["^(builder-|)victory"] }]
+  no-magic-numbers: ["error", { "ignore": [-1, 0, 1, 2] }]

--- a/config/eslint/.eslintrc-source
+++ b/config/eslint/.eslintrc-source
@@ -7,4 +7,4 @@ rules:
   # Don't check victory deps until bugfix for NODE_PATH uptream.
   # https://github.com/benmosher/eslint-plugin-import/issues/142
   import/no-unresolved: [2, { ignore: ["^(builder-|)victory"] }]
-  no-magic-numbers: ["error", { "ignore": [-1, 0, 1, 2] }]
+  no-magic-numbers: [error, { ignore: [-1, 0, 0.5, 1, 2] }]


### PR DESCRIPTION
These are the common ones that I believe make sense to be global exceptions. Others will be addressed on a case by case basis and extracted into constants where appropriate.

 - 0 and 1 are used for accessing two element domain and range arrays 
- -1 is used when reversing the orientation of an element (e.g. adding or subtracting padding depending on orientation)
- 2 halving and averaging values